### PR TITLE
fix: remoção do critério de aluno do IME para acessar o sistema

### DIFF
--- a/app/Http/Controllers/LoginController.php
+++ b/app/Http/Controllers/LoginController.php
@@ -8,6 +8,7 @@ use App\Models\User;
 use Laravel\Socialite\Facades\Socialite;
 use Illuminate\Support\Facades\Auth;
 use \Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 
 class LoginController extends Controller
 {
@@ -20,17 +21,19 @@ class LoginController extends Controller
 	{
 		$userSenhaUnica = Socialite::driver('senhaunica')->user();
 
-		$fromIME = false;
-        foreach ($userSenhaUnica->vinculo as $vinculo){
-            if (isset($vinculo["siglaUnidade"]) && $vinculo["siglaUnidade"] === 'IME') {
-                $fromIME = true;
-                break; 
-            }
-        }
+		Log::info('User login attempt: ', ['user_data' => json_encode($userSenhaUnica->user ?? $userSenhaUnica, JSON_PRETTY_PRINT)]);
+
+		// $fromIME = false;
+        // foreach ($userSenhaUnica->vinculo as $vinculo){
+        //     if (isset($vinculo["siglaUnidade"]) && $vinculo["siglaUnidade"] === 'IME') {
+        //         $fromIME = true;
+        //         break; 
+        //     }
+        // }
         
-        if (!$fromIME) {
-            abort(403, 'Acesso negado. Seu vínculo com o IME não foi encontrado. Se você for aluno do IME, entre em contato com o serviço de graduação.');
-        }
+        // if (!$fromIME) {
+        //     abort(403, 'Acesso negado. Seu vínculo com o IME não foi encontrado. Se você for aluno do IME, entre em contato com o serviço de graduação.');
+        // }
 
 		$user = User::where('codpes', $userSenhaUnica->codpes)->first();
 		if (is_null($user)) {


### PR DESCRIPTION
Com isso, evitamos de maneira rápida problemas com usuários de transferência externa recém chegados. Para um fix correto, seria necessário analisar o que o sistema está recebendo quando esses alunos logam no sistema. Foi adicionado um log para facilitar o debugging e a readição da feature no futuro.